### PR TITLE
Fix typo in update stage name

### DIFF
--- a/plex-media-serverupdates.json
+++ b/plex-media-serverupdates.json
@@ -1,6 +1,6 @@
 [
     {
-        "UpdateStageName": "Get Executeable",
+        "UpdateStageName": "Get Executable",
         "UpdateSourcePlatform": "Windows",
         "UpdateSource": "FetchURL",
         "UpdateSourceData": "https://plex.tv/downloads/latest/5?channel=public&build=windows-x86_64&distro=win",


### PR DESCRIPTION
## Summary
- fix the spelling of `Executable` in `plex-media-serverupdates.json`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68416c9bc098832eaf5e34b59c0637cb